### PR TITLE
Fix crashes on profile load and add result visibility option

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main page text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const textElements = screen.getAllByText(/Sistem Pendukung Keputusan/i);
+  expect(textElements.length).toBeGreaterThan(0);
 });

--- a/src/app/auth/profile/ProfileView.js
+++ b/src/app/auth/profile/ProfileView.js
@@ -84,7 +84,7 @@ class ProfileView extends Component {
                                                     {e.name}
                                                 </h1>
                                                 <p className="mt-2 text-gray-500 dark:text-gray-400">
-                                                    {e.deskripsi.substring(0, 120)}...
+                                                    {e.deskripsi ? e.deskripsi.substring(0, 120) : ""}...
                                                 </p>
                                                 <div className="flex items-center justify-between mt-4">
                                                     <div>
@@ -97,11 +97,11 @@ class ProfileView extends Component {
                                                         <p className="text-sm text-gray-500 dark:text-gray-400">
 
                                                             {
-                                                                new Intl.DateTimeFormat('id-ID', {
+                                                                e.createdAt && e.createdAt.toDate ? new Intl.DateTimeFormat('id-ID', {
                                                                     year: 'numeric',
                                                                     month: 'long',
                                                                     day: '2-digit',
-                                                                }).format(e.createdAt.toDate())
+                                                                }).format(e.createdAt.toDate()) : ""
                                                             }
 
                                                         </p>

--- a/src/app/dashboard/dashboard.js
+++ b/src/app/dashboard/dashboard.js
@@ -46,7 +46,9 @@ class Dashboard extends Component {
             querySnapshot.forEach((doc) => {
                 let data = doc.data();
                 data.id = doc.id;
-                listPerhitungan.push(data);
+                if (data.isPublic !== false) {
+                    listPerhitungan.push(data);
+                }
             });
             this.setState({ listPerhitungan, isLoading: false });
         });
@@ -145,7 +147,7 @@ class Dashboard extends Component {
                                                     {e.name}
                                                 </h1>
                                                 <p className="mt-2 text-gray-500 dark:text-gray-400">
-                                                    {e.deskripsi.substring(0, 120)}...
+                                                    {e.deskripsi ? e.deskripsi.substring(0, 120) : ""}...
                                                 </p>
                                                 <div className="flex items-center justify-between mt-4">
                                                     <div>
@@ -158,11 +160,11 @@ class Dashboard extends Component {
                                                         <p className="text-sm text-gray-500 dark:text-gray-400">
 
                                                             {
-                                                                new Intl.DateTimeFormat('id-ID', {
+                                                                e.createdAt && e.createdAt.toDate ? new Intl.DateTimeFormat('id-ID', {
                                                                     year: 'numeric',
                                                                     month: 'long',
                                                                     day: '2-digit'
-                                                                }).format(e.createdAt.toDate())
+                                                                }).format(e.createdAt.toDate()) : ""
                                                             }
 
                                                         </p>

--- a/src/app/dashboard/input.js
+++ b/src/app/dashboard/input.js
@@ -56,6 +56,7 @@ class InputView extends Component {
                 kriteria: [],
                 alternatif: [],
                 deskripsi: '',
+                isPublic: true,
             },
             isDialogOpen: false,
             errorWarning: false,

--- a/src/app/dashboard/input1.js
+++ b/src/app/dashboard/input1.js
@@ -10,7 +10,11 @@ class Input1 extends Component {
 
     changeHandler = (e) => {
         let newPerhitungan = { ...this.state.perhitungan };
-        newPerhitungan[e.target.name] = e.target.value;
+        if (e.target.name === "isPublic") {
+            newPerhitungan[e.target.name] = e.target.checked;
+        } else {
+            newPerhitungan[e.target.name] = e.target.value;
+        }
         this.props.handler(newPerhitungan)
         this.setState({ perhitungan: newPerhitungan });
 
@@ -141,6 +145,23 @@ class Input1 extends Component {
                                     defaultValue={perhitungan.deskripsi}
                                     onChange={this.changeHandler}
                                 />
+                            </div>
+
+                            <div className="sm:col-span-2 flex items-center">
+                                <input
+                                    type="checkbox"
+                                    name="isPublic"
+                                    id="isPublic"
+                                    className="w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                                    defaultChecked={perhitungan.isPublic !== false}
+                                    onChange={this.changeHandler}
+                                />
+                                <label
+                                    htmlFor="isPublic"
+                                    className="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+                                >
+                                    Jadikan Publik (Dapat dilihat oleh semua orang)
+                                </label>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
This pull request addresses the user crashes originating from missing fields in historic items and introduces a visibility parameter so results can be explicitly marked as private or public.

---
*PR created automatically by Jules for task [12328033680512064223](https://jules.google.com/task/12328033680512064223) started by @AkhmadRamadani*